### PR TITLE
Fix  mismatch between the music configuration keys inC++ code and the keys defined in configuration file

### DIFF
--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -536,11 +536,11 @@ void LoadCitySiegeConfiguration()
     g_WeatherGrade = sConfigMgr->GetOption<float>("CitySiege.Weather.Grade", 0.8f);
 
     // Music settings
-    g_MusicEnabled = sConfigMgr->GetOption<bool>("CitySiege.Music.Enabled", true);
-    g_RPMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.RP", 11803);        // The Burning Legion
-    g_CombatMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.Combat", 11804); // Battle of Mount Hyjal
-    g_VictoryMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.Victory", 16039); // Invincible
-    g_DefeatMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.Defeat", 14127);   // Wrath of the Lich King
+    g_MusicEnabled   = sConfigMgr->GetOption<bool>("CitySiege.Music.Enabled", true);
+    g_RPMusicId      = sConfigMgr->GetOption<uint32>("CitySiege.Music.RPMusicId", 17289);        // The Burning Legion
+    g_CombatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.CombatMusicId", 17459); // Battle of Mount Hyjal
+    g_VictoryMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.VictoryMusicId", 17460); // Invincible
+    g_DefeatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.DefeatMusicId", 17458);   // Wrath of the Lich King
 
     // Load spawn locations for each city
     g_Cities[CITY_STORMWIND].spawnX = sConfigMgr->GetOption<float>("CitySiege.Stormwind.SpawnX", -9161.16f);

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -537,10 +537,10 @@ void LoadCitySiegeConfiguration()
 
     // Music settings
     g_MusicEnabled   = sConfigMgr->GetOption<bool>("CitySiege.Music.Enabled", true);
-    g_RPMusicId      = sConfigMgr->GetOption<uint32>("CitySiege.Music.RPMusicId", 17289);        // The Burning Legion
-    g_CombatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.CombatMusicId", 17459); // Battle of Mount Hyjal
-    g_VictoryMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.VictoryMusicId", 17460); // Invincible
-    g_DefeatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.DefeatMusicId", 17458);   // Wrath of the Lich King
+    g_RPMusicId      = sConfigMgr->GetOption<uint32>("CitySiege.Music.RPMusicId", 11803);        // The Burning Legion
+    g_CombatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.CombatMusicId", 11804); // Battle of Mount Hyjal
+    g_VictoryMusicId = sConfigMgr->GetOption<uint32>("CitySiege.Music.VictoryMusicId", 16039); // Invincible
+    g_DefeatMusicId  = sConfigMgr->GetOption<uint32>("CitySiege.Music.DefeatMusicId", 14127);   // Wrath of the Lich King
 
     // Load spawn locations for each city
     g_Cities[CITY_STORMWIND].spawnX = sConfigMgr->GetOption<float>("CitySiege.Stormwind.SpawnX", -9161.16f);


### PR DESCRIPTION
This PR fixes a mismatch between the music configuration keys used in the CitySiege C++ code and the keys defined in the module configuration file.

Previously, the code was reading:
- CitySiege.Music.RP
- CitySiege.Music.Combat
- CitySiege.Music.Victory
- CitySiege.Music.Defeat

while the configuration file defined:
- CitySiege.Music.RPMusicId
- CitySiege.Music.CombatMusicId
- CitySiege.Music.VictoryMusicId
- CitySiege.Music.DefeatMusicId

As a result, the custom music IDs set in the config were never applied and the hardcoded default values were always used.

This change aligns the code with the configuration file (and updates the default values accordingly), so that:
- music settings from the config are correctly loaded,
- the documented defaults now match the actual runtime behavior.

No other functionality is changed.