### PR TITLE
Improve addon sync and expose active siege role APIs

### DIFF
--- a/ADDON_DATA_SYNC_COMPLETED.md
+++ b/ADDON_DATA_SYNC_COMPLETED.md
@@ -1,16 +1,15 @@
 # City Siege Addon - Complete Data Synchronization Implementation
 
 ## Summary
-Implemented comprehensive server-to-addon data synchronization system for City Siege module. The system now broadcasts ALL siege data silently in the background every 30 seconds and supports on-demand data requests.
+Implemented a comprehensive server-to-addon data synchronization system for City Siege. The system broadcasts periodic siege snapshots silently in the background every 30 seconds and supports on-demand data requests.
 
 ## Changes Made
 
 ### 1. Server-Side (mod-city-siege.cpp)
 
-#### Enhanced `BroadcastSiegeDataToAddon()` Function (Line ~768)
-- **Purpose**: Sends comprehensive siege data to players within range
+#### Enhanced `BroadcastSiegeDataToAddon()` Function
+- **Purpose**: Sends comprehensive siege data to online players
 - **Frequency**: Every 30 seconds automatic broadcast
-- **Range**: 500 yards from city center
 - **Communication**: Silent (WorldPacket with SMSG_MESSAGECHAT, CHAT_MSG_SYSTEM)
 
 **Data Transmitted**:
@@ -18,8 +17,8 @@ Implemented comprehensive server-to-addon data synchronization system for City S
 2. **Time Remaining**: Calculated from event duration
 3. **Leader Health**: Percentage from leader creature HP
 4. **Waypoints**: All waypoint coordinates (x,y,z)
-5. **Attacker NPC Positions**: Up to 50 NPC positions (x,y,z)
-6. **Defender NPC Positions**: Up to 50 NPC positions (x,y,z)
+5. **Attacker NPC Positions**: Active attacker creature positions (x,y,z)
+6. **Defender NPC Positions**: Active defender creature positions (x,y,z)
 7. **Attacker Bot Positions**: All bot positions (x,y,z)
 8. **Defender Bot Positions**: All bot positions (x,y,z)
 9. **Location Data**: Spawn point, leader position, city center
@@ -102,7 +101,7 @@ CITYSIEGE_UPDATE:cityId:phase:atk:def:elapsed:remaining:leaderHP:WP:count:x:y:z.
 - **Packet Size**: Increased from 200 to 2000 bytes
 - **Position Limits**: 50 NPCs per side (prevents overflow)
 - **Update Frequency**: 30 seconds (balance between freshness and bandwidth)
-- **Range Filtering**: Only sends to players within 500 yards
+- **Delivery**: Sent to online players so the addon can sync regardless of location
 
 ### Communication Protocol
 - **Channel**: SMSG_MESSAGECHAT with CHAT_MSG_SYSTEM
@@ -193,4 +192,4 @@ Potential improvements for future versions:
 
 ## Version
 Implementation Date: 2025
-Status: Complete and Ready for Testing
+Status: Implemented and Ready for Testing

--- a/ClientAddon/CitySiege/Core.lua
+++ b/ClientAddon/CitySiege/Core.lua
@@ -123,8 +123,12 @@ end
 
 function Core:PLAYER_REGEN_DISABLED()
     -- Entered combat
-    if CitySiege_MainFrame and not CitySiege_Config:GetUISettings().showInCombat then
-        if CitySiege_MainFrame.Hide then
+    if CitySiege_MainFrame then
+        CitySiege_MainFrame.wasShownBeforeCombat = CitySiege_MainFrame:IsShown()
+
+        if not CitySiege_Config:GetUISettings().showInCombat and
+           CitySiege_MainFrame.wasShownBeforeCombat and
+           CitySiege_MainFrame.Hide then
             CitySiege_MainFrame:Hide()
         end
     end
@@ -132,10 +136,16 @@ end
 
 function Core:PLAYER_REGEN_ENABLED()
     -- Left combat
-    if CitySiege_MainFrame and CitySiege_Config:GetUISettings().showInCombat then
-        if CitySiege_MainFrame.wasShownBeforeCombat then
+    if CitySiege_MainFrame and
+       not CitySiege_Config:GetUISettings().showInCombat and
+       CitySiege_MainFrame.wasShownBeforeCombat then
+        if CitySiege_MainFrame.Show then
             CitySiege_MainFrame:Show()
         end
+    end
+
+    if CitySiege_MainFrame then
+        CitySiege_MainFrame.wasShownBeforeCombat = false
     end
 end
 
@@ -258,7 +268,7 @@ function Core:ShowHelp()
     CitySiege_Utils:Print("|cFFFFFF00/cs start [city]|r - Start a siege (GM only)")
     CitySiege_Utils:Print("|cFFFFFF00/cs stop [city] [faction]|r - Stop a siege (GM only)")
     CitySiege_Utils:Print("|cFFFFFF00/cs cleanup [city]|r - Clean up siege NPCs (GM only)")
-    CitySiege_Utils:Print("|cFFFFFF00/cs info|r - Show detailed info (GM only)")
+    CitySiege_Utils:Print("|cFFFFFF00/cs info|r - Show info for your selected siege NPC/playerbot (GM only)")
     CitySiege_Utils:Print("|cFFFFFF00/cs reload|r - Reload config (Admin only)")
     CitySiege_Utils:Print("|cFFFFFF00/cs reset|r - Reset addon settings")
     CitySiege_Utils:Print("|cFF00FF00/cs testmap [cityID]|r - Enable test mode with demo data")
@@ -299,7 +309,7 @@ function Core:ToggleMinimap()
 end
 
 function Core:RequestStatus()
-    SendChatMessage(".citysiege sync", "GUILD")
+    CitySiege_Utils:ExecuteServerCommand(".citysiege sync")
     -- Silent operation - no user-facing message
 end
 
@@ -308,7 +318,7 @@ function Core:SendCommand(cmd, arg1, arg2)
     if arg1 then command = command .. " " .. arg1 end
     if arg2 then command = command .. " " .. arg2 end
     
-    SendChatMessage(command, "GUILD")
+    CitySiege_Utils:ExecuteServerCommand(command)
     CitySiege_Utils:Print("Command sent: " .. command)
 end
 

--- a/ClientAddon/CitySiege/Core.lua
+++ b/ClientAddon/CitySiege/Core.lua
@@ -299,7 +299,7 @@ function Core:ToggleMinimap()
 end
 
 function Core:RequestStatus()
-    SendChatMessage(".citysiege status", "GUILD")
+    SendChatMessage(".citysiege sync", "GUILD")
     -- Silent operation - no user-facing message
 end
 

--- a/ClientAddon/CitySiege/Modules/CommandPanel.lua
+++ b/ClientAddon/CitySiege/Modules/CommandPanel.lua
@@ -43,7 +43,7 @@ function CommandPanel:Create(parent)
     -- Start Siege button
     frame.startButton = self:CreateCommandButton(buttonsFrame, "Start Siege", function()
         if frame.currentCity then
-            SendChatMessage(".citysiege start " .. frame.currentCity.name, "GUILD")
+            CitySiege_Utils:ExecuteServerCommand(".citysiege start " .. frame.currentCity.name)
             CitySiege_Utils:Print("Starting siege in " .. frame.currentCity.displayName)
         end
     end, buttonWidth, buttonHeight)
@@ -54,7 +54,7 @@ function CommandPanel:Create(parent)
     frame.stopButton = self:CreateCommandButton(buttonsFrame, "Stop Siege", function()
         if frame.currentCity then
             local faction = CitySiege_Utils:GetPlayerFaction()
-            SendChatMessage(string.format(".citysiege stop %s %s", frame.currentCity.name, faction), "GUILD")
+            CitySiege_Utils:ExecuteServerCommand(string.format(".citysiege stop %s %s", frame.currentCity.name, faction))
             CitySiege_Utils:Print("Stopping siege in " .. frame.currentCity.displayName)
         end
     end, buttonWidth, buttonHeight)
@@ -64,7 +64,7 @@ function CommandPanel:Create(parent)
     -- Cleanup button
     frame.cleanupButton = self:CreateCommandButton(buttonsFrame, "Cleanup NPCs", function()
         if frame.currentCity then
-            SendChatMessage(".citysiege cleanup " .. frame.currentCity.name, "GUILD")
+            CitySiege_Utils:ExecuteServerCommand(".citysiege cleanup " .. frame.currentCity.name)
             CitySiege_Utils:Print("Cleaning up siege NPCs in " .. frame.currentCity.displayName)
         end
     end, buttonWidth, buttonHeight)
@@ -73,28 +73,29 @@ function CommandPanel:Create(parent)
     
     -- Status button
     frame.statusButton = self:CreateCommandButton(buttonsFrame, "Show Status", function()
-        SendChatMessage(".citysiege status", "GUILD")
+        CitySiege_Utils:ExecuteServerCommand(".citysiege status")
     end, buttonWidth, buttonHeight)
     frame.statusButton:SetPoint("TOP", 0, buttonY)
     buttonY = buttonY - buttonSpacing
     
     -- Info button
-    frame.infoButton = self:CreateCommandButton(buttonsFrame, "Detailed Info", function()
-        SendChatMessage(".citysiege info", "GUILD")
+    frame.infoButton = self:CreateCommandButton(buttonsFrame, "Selected Unit Info", function()
+        CitySiege_Utils:ExecuteServerCommand(".citysiege info")
+        CitySiege_Utils:Print("Select a siege NPC or playerbot before using Selected Unit Info.")
     end, buttonWidth, buttonHeight)
     frame.infoButton:SetPoint("TOP", 0, buttonY)
     buttonY = buttonY - buttonSpacing
     
     -- Reload button
     frame.reloadButton = self:CreateCommandButton(buttonsFrame, "Reload Config", function()
-        SendChatMessage(".citysiege reload", "GUILD")
+        CitySiege_Utils:ExecuteServerCommand(".citysiege reload")
     end, buttonWidth, buttonHeight)
     frame.reloadButton:SetPoint("TOP", 0, buttonY)
     
     -- Warning text
     local warning = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
     warning:SetPoint("BOTTOM", 0, 25)
-    warning:SetText("|cFFFF8800Note: GM/Admin commands only|r")
+    warning:SetText("|cFFFF8800Note: GM/Admin commands only. Unit Info requires a selected siege unit.|r")
     
     return frame
 end

--- a/ClientAddon/CitySiege/Modules/EventHandler.lua
+++ b/ClientAddon/CitySiege/Modules/EventHandler.lua
@@ -103,10 +103,7 @@ function EventHandler:ParseAddonMessage(message)
         
         if #parts >= 2 then
             local cityID = tonumber(parts[2])
-            print("CitySiege: Requesting map data from server for city " .. cityID)
-            -- Use SendChatMessage instead of RunMacroText to avoid permission issues
-            -- This sends the command to the server which is available to all players (SEC_PLAYER)
-            SendChatMessage(".citysiege mapdata " .. cityID, "GUILD")
+            CitySiege_Utils:ExecuteServerCommand(".citysiege mapdata " .. cityID)
         end
         return
         
@@ -156,10 +153,32 @@ function EventHandler:ParseAddonMessage(message)
             
             -- Parse waypoints, attacker positions, defender positions, bot positions
             local data = {
-                waypoints = {}
+                waypoints = {},
+                attackerPositions = {},
+                defenderPositions = {},
+                attackerBots = {},
+                defenderBots = {}
             }
-            
+
             local i = 9
+
+            local function parsePositionSection(target)
+                i = i + 1
+                local count = tonumber(parts[i]) or 0
+                i = i + 1
+
+                for j = 1, count do
+                    if i + 2 <= #parts then
+                        table.insert(target, {
+                            x = tonumber(parts[i]),
+                            y = tonumber(parts[i + 1]),
+                            z = tonumber(parts[i + 2])
+                        })
+                        i = i + 3
+                    end
+                end
+            end
+            
             while i <= #parts do
                 local section = parts[i]
                 
@@ -178,6 +197,14 @@ function EventHandler:ParseAddonMessage(message)
                             i = i + 3
                         end
                     end
+                elseif section == "ATK" then
+                    parsePositionSection(data.attackerPositions)
+                elseif section == "DEF" then
+                    parsePositionSection(data.defenderPositions)
+                elseif section == "BATK" then
+                    parsePositionSection(data.attackerBots)
+                elseif section == "BDEF" then
+                    parsePositionSection(data.defenderBots)
                 else
                     i = i + 1
                 end
@@ -195,19 +222,13 @@ function EventHandler:ParseAddonMessage(message)
         
     elseif command == "MAP_DATA" then
         -- Format: MAP_DATA:cityID:WP:count:x:y:z...:LEADER:x:y:z
-        print("CitySiege: Received MAP_DATA command")
-        print("CitySiege: Full message: " .. tostring(message))
-        
         local parts = {}
         for part in string.gmatch(message, "([^:]+)") do
             table.insert(parts, part)
         end
         
-        print("CitySiege: Parsed " .. #parts .. " parts")
-        
         if #parts >= 2 then
             local cityID = tonumber(parts[2])
-            print("CitySiege: CityID: " .. tostring(cityID))
             
             local data = {
                 waypoints = {},
@@ -222,7 +243,6 @@ function EventHandler:ParseAddonMessage(message)
                     -- Waypoints
                     i = i + 1
                     local wpCount = tonumber(parts[i]) or 0
-                    print("CitySiege: Found " .. wpCount .. " waypoints")
                     i = i + 1
                     for j = 1, wpCount do
                         if i + 2 <= #parts then
@@ -231,7 +251,6 @@ function EventHandler:ParseAddonMessage(message)
                                 y = tonumber(parts[i + 1]),
                                 z = tonumber(parts[i + 2])
                             }
-                            print(string.format("CitySiege: Waypoint %d: %.2f, %.2f, %.2f", j, wp.x, wp.y, wp.z))
                             table.insert(data.waypoints, wp)
                             i = i + 3
                         end
@@ -245,23 +264,16 @@ function EventHandler:ParseAddonMessage(message)
                             y = tonumber(parts[i + 2]),
                             z = tonumber(parts[i + 3])
                         }
-                        print(string.format("CitySiege: Leader pos: %.2f, %.2f, %.2f", 
-                            data.leaderPos.x, data.leaderPos.y, data.leaderPos.z))
                         i = i + 4
                     end
                 else
                     i = i + 1
                 end
             end
-            
-            print("CitySiege: Total waypoints parsed: " .. #data.waypoints)
-            
+
             -- Send to MapDisplay
             if CitySiege_MapDisplay then
-                print("CitySiege: Calling MapDisplay:UpdateMapData")
                 CitySiege_MapDisplay:UpdateMapData(cityID, data)
-            else
-                print("CitySiege: ERROR - CitySiege_MapDisplay is nil!")
             end
         end
     end
@@ -340,6 +352,10 @@ function EventHandler:HandleSiegeUpdate(cityID, phase, attackerCount, defenderCo
             -- Update waypoint data if provided
             if data then
                 siegeData.waypoints = data.waypoints or {}
+                siegeData.attackerPositions = data.attackerPositions or {}
+                siegeData.defenderPositions = data.defenderPositions or {}
+                siegeData.attackerBots = data.attackerBots or {}
+                siegeData.defenderBots = data.defenderBots or {}
             end
             
             if not siegeData.stats then
@@ -415,6 +431,6 @@ function EventHandler:SendToServer(command, ...)
         SendAddonMessage("CitySiege", message, "GUILD")
     else
         -- Fallback: Use chat command (server should handle this)
-        SendChatMessage(".citysiege " .. message, "GUILD")
+        CitySiege_Utils:ExecuteServerCommand(".citysiege " .. message)
     end
 end

--- a/ClientAddon/CitySiege/Modules/MainFrame.lua
+++ b/ClientAddon/CitySiege/Modules/MainFrame.lua
@@ -250,9 +250,6 @@ function MainFrame:CreateTabContent()
     frame.mapContent:SetPoint("BOTTOMRIGHT", -5, 5)
     frame.mapContent:Hide()
     
-    print("CitySiege MainFrame: About to create MapDisplay")
-    print("CitySiege MainFrame: CitySiege_MapDisplay exists: " .. tostring(CitySiege_MapDisplay ~= nil))
-    
     if CitySiege_MapDisplay then
         local success, result = pcall(function()
             return CitySiege_MapDisplay:Create(frame.mapContent)
@@ -261,12 +258,7 @@ function MainFrame:CreateTabContent()
         if success then
             -- Store reference to the module, not just the frame
             mapDisplay = CitySiege_MapDisplay
-            print("CitySiege MainFrame: MapDisplay created successfully, result: " .. tostring(result))
-        else
-            print("CitySiege MainFrame: ERROR creating MapDisplay: " .. tostring(result))
         end
-    else
-        print("CitySiege MainFrame: ERROR - CitySiege_MapDisplay module not loaded!")
     end
     
     -- Info tab
@@ -364,22 +356,17 @@ function MainFrame:ShowTab(tabIndex)
         frame.commandsContent:Show()
     elseif tabIndex == 2 and frame.mapContent then
         frame.mapContent:Show()
-        print("CitySiege: Showing Map tab, currentCityID: " .. tostring(currentCityID))
         if mapDisplay then
-            print("CitySiege: mapDisplay frame exists, calling CitySiege_MapDisplay:SetCity")
             CitySiege_MapDisplay:SetCity(currentCityID)
             
             -- Request map data from server if a city is selected
             if currentCityID then
-                print("CitySiege: Requesting map data for city " .. currentCityID)
                 -- Trigger local REQUEST_MAP handling which will execute the server command
                 -- This allows non-GM players to request map data
                 if CitySiege_EventHandler then
                     CitySiege_EventHandler:ParseAddonMessage("REQUEST_MAP:" .. currentCityID)
                 end
             end
-        else
-            print("CitySiege: ERROR - mapDisplay frame is nil!")
         end
     elseif tabIndex == 3 and frame.infoContent then
         frame.infoContent:Show()
@@ -391,11 +378,7 @@ function MainFrame:ShowTab(tabIndex)
 end
 
 function MainFrame:SelectCity(cityID)
-    print("CitySiege: SelectCity called with cityID: " .. tostring(cityID))
-    
     currentCityID = cityID
-    
-    print("CitySiege: currentCityID set to: " .. tostring(currentCityID))
     
     -- Update CommandPanel with the selected city
     if commandPanel then
@@ -599,42 +582,9 @@ function MainFrame:UpdateStatsText()
         text = text .. "Win Rate: |cFF808080N/A|r\n\n"
     end
     
-    -- Combat Statistics
     text = text .. "|cFF00FF00=== Combat Statistics ===|r\n"
-    text = text .. string.format("Total Kills: |cFF00FF00%s|r\n", CitySiege_Utils:FormatNumber(stats.totalKills or 0))
-    text = text .. string.format("Total Deaths: |cFFFF0000%s|r\n", CitySiege_Utils:FormatNumber(stats.totalDeaths or 0))
-    
-    -- K/D Ratio
-    if stats.totalDeaths and stats.totalDeaths > 0 then
-        local kd = (stats.totalKills or 0) / stats.totalDeaths
-        local color = kd >= 2.0 and "|cFF00FF00" or (kd >= 1.0 and "|cFFFFFF00" or "|cFFFF0000")
-        text = text .. string.format("K/D Ratio: %s%.2f|r\n\n", color, kd)
-    else
-        text = text .. "K/D Ratio: |cFF808080N/A|r\n\n"
-    end
-    
-    -- Averages
-    if stats.siegesParticipated and stats.siegesParticipated > 0 then
-        local avgKills = (stats.totalKills or 0) / stats.siegesParticipated
-        local avgDeaths = (stats.totalDeaths or 0) / stats.siegesParticipated
-        text = text .. "|cFF00FF00=== Averages Per Siege ===|r\n"
-        text = text .. string.format("Avg Kills: |cFFFFFFFF%.1f|r\n", avgKills)
-        text = text .. string.format("Avg Deaths: |cFFFFFFFF%.1f|r\n\n", avgDeaths)
-    end
-    
-    -- Role Performance (if data available)
-    if stats.attackerSieges or stats.defenderSieges then
-        text = text .. "|cFF00FF00=== Role Performance ===|r\n"
-        text = text .. string.format("As Attacker: |cFFFF0000%d|r sieges\n", stats.attackerSieges or 0)
-        text = text .. string.format("As Defender: |cFF0088FF%d|r sieges\n\n", stats.defenderSieges or 0)
-    end
-    
-    -- City-specific stats (if available)
-    if stats.citiesAttacked or stats.citiesDefended then
-        text = text .. "|cFF00FF00=== City Experience ===|r\n"
-        text = text .. string.format("Cities Attacked: %d\n", stats.citiesAttacked or 0)
-        text = text .. string.format("Cities Defended: %d\n\n", stats.citiesDefended or 0)
-    end
+    text = text .. "Combat kills and deaths are not currently synchronized\n"
+    text = text .. "by the City Siege server addon bridge.\n\n"
     
     -- Performance Rating
     if hasExperience then
@@ -659,7 +609,7 @@ function MainFrame:UpdateStatsText()
         text = text .. string.format("Rank: %s%s|r\n", ratingColor, rating)
     end
     
-    text = text .. "\n|cFF808080Stats update in real-time during sieges|r"
+    text = text .. "\n|cFF808080Tracked stats update when completed sieges end.|r"
     
     if frame.statsContent and frame.statsContent.statsText then
         frame.statsContent.statsText:SetText(text)

--- a/ClientAddon/CitySiege/Modules/MapDisplay.lua
+++ b/ClientAddon/CitySiege/Modules/MapDisplay.lua
@@ -13,14 +13,9 @@ local lines = {}
 local updateThrottle = 0
 
 function MapDisplay:Create(parent)
-    print("CitySiege MapDisplay: Create() called")
-    
     if frame then 
-        print("CitySiege MapDisplay: Frame already exists, returning existing frame")
         return frame 
     end
-    
-    print("CitySiege MapDisplay: Creating new frame")
     
     frame = CreateFrame("Frame", "CitySiegeMapDisplay", parent)
     frame:SetAllPoints(parent)
@@ -89,15 +84,11 @@ function MapDisplay:Create(parent)
     noSiegeText:Show()
     frame.noSiegeText = noSiegeText
     
-    print("CitySiege: MapDisplay created successfully")
-    
     return frame
 end
 
 function MapDisplay:SetCity(cityID)
     currentCityID = cityID
-    
-    print("CitySiege MapDisplay: SetCity called with cityID: " .. tostring(cityID))
     
     if not cityID then
         -- Show placeholder when no city selected
@@ -140,8 +131,6 @@ function MapDisplay:SetCity(cityID)
     
     -- Set city map texture using our custom map files
     if frame and frame.mapTexture then
-        print("CitySiege MapDisplay: frame and mapTexture exist")
-        
         -- Map city names to file names (use actual folder names)
         local mapFiles = {
             [CitySiege_Cities.STORMWIND] = "Stormwind",
@@ -154,9 +143,7 @@ function MapDisplay:SetCity(cityID)
             [CitySiege_Cities.SILVERMOON] = "SilvermoonCity",
         }
         
-        print("CitySiege MapDisplay: Looking up map file for cityID: " .. tostring(cityID))
         local mapFile = mapFiles[cityID]
-        print("CitySiege MapDisplay: mapFile = " .. tostring(mapFile))
         if mapFile then
             -- BLP files (no extension needed, WoW adds .blp automatically)
             local texturePath = "Interface\\AddOns\\CitySiege\\Media\\Maps\\" .. mapFile
@@ -170,13 +157,9 @@ function MapDisplay:SetCity(cityID)
             if frame.noMapText then frame.noMapText:Hide() end
             if frame.noSiegeText then frame.noSiegeText:Hide() end
             
-            print("CitySiege: Texture set for " .. cityData.displayName)
         else
-            print("CitySiege: No map file found for city ID: " .. tostring(cityID))
             MapDisplay:ShowMapFallback(cityID, cityData, nil)
         end
-    else
-        print("CitySiege MapDisplay: ERROR - frame or mapTexture is nil")
     end
 end
 
@@ -581,20 +564,13 @@ function MapDisplay:Show()
 end
 
 function MapDisplay:UpdateMapData(cityID, data)
-    print("CitySiege MapDisplay: UpdateMapData called")
-    print("CitySiege MapDisplay: cityID=" .. tostring(cityID) .. ", currentCityID=" .. tostring(currentCityID))
-    print("CitySiege MapDisplay: frame=" .. tostring(frame) .. ", data=" .. tostring(data))
-    
     if not frame or not data then 
-        print("CitySiege MapDisplay: ERROR - frame or data is nil!")
         return 
     end
     if currentCityID ~= cityID then 
-        print("CitySiege MapDisplay: ERROR - cityID mismatch!")
         return 
     end
-    
-    print("CitySiege MapDisplay: Clearing existing icons")
+
     -- Clear existing icons
     if frame.mapIcons then
         for _, icon in ipairs(frame.mapIcons) do
@@ -605,27 +581,17 @@ function MapDisplay:UpdateMapData(cityID, data)
     
     -- Add waypoint icons
     if data.waypoints then
-        print("CitySiege MapDisplay: Adding " .. #data.waypoints .. " waypoint icons")
         for i, wp in ipairs(data.waypoints) do
-            print(string.format("CitySiege MapDisplay: Creating waypoint icon %d at %.2f, %.2f, %.2f", 
-                i, wp.x, wp.y, wp.z))
             local icon = MapDisplay:CreateIcon(wp.x, wp.y, wp.z, "waypoint", i)
             table.insert(frame.mapIcons, icon)
         end
-    else
-        print("CitySiege MapDisplay: No waypoints in data")
     end
     
     -- Add leader icon
     if data.leaderPos then
-        print("CitySiege MapDisplay: Adding leader icon")
         local icon = MapDisplay:CreateIcon(data.leaderPos.x, data.leaderPos.y, data.leaderPos.z, "leader")
         table.insert(frame.mapIcons, icon)
-    else
-        print("CitySiege MapDisplay: No leader position in data")
     end
-    
-    print("CitySiege MapDisplay: Total icons created: " .. #frame.mapIcons)
 end
 
 function MapDisplay:CreateIcon(x, y, z, iconType, index)

--- a/ClientAddon/CitySiege/Modules/SiegeTracker.lua
+++ b/ClientAddon/CitySiege/Modules/SiegeTracker.lua
@@ -278,8 +278,8 @@ function Tracker:GetNPCs(cityID)
 end
 
 function Tracker:RequestStatusUpdate()
-    -- Send command to get status (silent operation)
-    SendChatMessage(".citysiege status", "GUILD")
+    -- Request authoritative addon sync instead of parsing human-readable status text.
+    SendChatMessage(".citysiege sync", "GUILD")
 end
 
 function Tracker:CheckCitySiege(cityID)

--- a/ClientAddon/CitySiege/Modules/SiegeTracker.lua
+++ b/ClientAddon/CitySiege/Modules/SiegeTracker.lua
@@ -160,8 +160,17 @@ function Tracker:RemoveSiege(cityID, winner)
         end
     end
     
-    -- Update statistics
-    CitySiege_Config:IncrementStat("siegesParticipated", 1)
+    -- Update tracked statistics only for completed sieges with a real winner.
+    if winner == "Alliance" or winner == "Horde" then
+        CitySiege_Config:IncrementStat("siegesParticipated", 1)
+
+        local playerFaction = UnitFactionGroup("player")
+        if playerFaction == winner then
+            CitySiege_Config:IncrementStat("siegesWon", 1)
+        else
+            CitySiege_Config:IncrementStat("siegesLost", 1)
+        end
+    end
     
     -- Remove from active sieges
     activeSieges[cityID] = nil
@@ -279,7 +288,7 @@ end
 
 function Tracker:RequestStatusUpdate()
     -- Request authoritative addon sync instead of parsing human-readable status text.
-    SendChatMessage(".citysiege sync", "GUILD")
+    CitySiege_Utils:ExecuteServerCommand(".citysiege sync")
 end
 
 function Tracker:CheckCitySiege(cityID)

--- a/ClientAddon/CitySiege/Utils.lua
+++ b/ClientAddon/CitySiege/Utils.lua
@@ -100,6 +100,16 @@ function Utils:Print(msg, r, g, b)
     DEFAULT_CHAT_FRAME:AddMessage("|cFF16C3F2[City Siege]|r " .. msg)
 end
 
+function Utils:ExecuteServerCommand(command)
+    if not command or command == "" then
+        return false
+    end
+
+    local chatType = (IsInGuild and IsInGuild()) and "GUILD" or "SAY"
+    SendChatMessage(command, chatType)
+    return true
+end
+
 -- Print debug message (only if debug enabled)
 function Utils:Debug(msg)
     -- Debug disabled

--- a/ClientAddon/INSTALLATION.md
+++ b/ClientAddon/INSTALLATION.md
@@ -121,7 +121,7 @@ If the `AddOns` folder doesn't exist, create it.
 ### Problem: Addon loads but shows errors
 
 **Solution:**
-1. Check that all required libraries are installed
+1. Check that the bundled `Libs/` directory is present inside `CitySiege`
 2. Install BugSack addon to see detailed errors:
    ```
    /bugsack
@@ -134,7 +134,7 @@ If the `AddOns` folder doesn't exist, create it.
 **Solution:**
 1. Type `/cs minimap` to toggle it
 2. Check if it's hidden in settings
-3. Verify LibDataBroker and LibDBIcon are installed
+3. Verify the bundled LibDataBroker and LibDBIcon folders are present under `CitySiege/Libs/`
 4. Reset minimap button position in settings
 
 ### Problem: Commands don't work
@@ -144,6 +144,7 @@ If the `AddOns` folder doesn't exist, create it.
 2. Check that the server has the City Siege module enabled
 3. Try using the full command: `.citysiege status` in chat
 4. Ensure you're connected to a server with the module
+5. If you're not in a guild, the addon falls back to normal chat command handling instead of guild chat
 
 ### Problem: Map doesn't show positions
 

--- a/ClientAddon/QUICK_REFERENCE.md
+++ b/ClientAddon/QUICK_REFERENCE.md
@@ -3,7 +3,7 @@
 ## 🚀 Quick Start
 
 1. **Install addon** → Copy `CitySiege` folder to `WoW/Interface/AddOns/`
-2. **Install libraries** → Download Ace3 from CurseForge, copy Libs to `CitySiege/Libs/`
+2. **Libraries are bundled** → Keep the included `Libs/` folder inside `CitySiege/`
 3. **Launch WoW** → Enable addon at character select
 4. **Open addon** → Click minimap button or type `/cs`
 
@@ -32,7 +32,7 @@
 | **Commands** | Execute GM siege commands with buttons |
 | **Map** | Live visualization of siege battlefield |
 | **Info** | Active siege details and status |
-| **Stats** | Your personal performance statistics |
+| **Stats** | Your tracked siege participation and outcomes |
 
 ## 🎨 Color Guide
 
@@ -86,16 +86,16 @@
 | Stop | `.citysiege stop [city] [faction]` | End a siege |
 | Cleanup | `.citysiege cleanup [city]` | Remove NPCs |
 | Status | `.citysiege status` | Show all sieges |
-| Info | `.citysiege info` | Detailed information |
+| Info | `.citysiege info` | Info for selected siege NPC/playerbot |
 | Reload | `.citysiege reload` | Refresh config |
 
 ## 🔧 Troubleshooting Quick Fixes
 
 | Problem | Solution |
 |---------|----------|
-| **Addon won't load** | Check libraries are installed; verify folder name is `CitySiege` |
+| **Addon won't load** | Check bundled libraries are present; verify folder name is `CitySiege` |
 | **No minimap button** | Type `/cs minimap` to unhide |
-| **Lua errors** | Install BugSack addon; check all Ace3 libs present |
+| **Lua errors** | Install BugSack addon; check all bundled library folders are present |
 | **Commands fail** | Need GM permissions; check server has module |
 | **Map empty** | Ensure siege is active; check map settings toggles |
 | **Settings reset** | Check SavedVariables folder wasn't deleted |
@@ -107,9 +107,7 @@
 | **Participated** | Number of sieges you've joined |
 | **Won/Lost** | Your siege victory record |
 | **Win Rate** | Percentage of sieges won |
-| **Total Kills** | Enemy players killed |
-| **Total Deaths** | Times you died |
-| **K/D Ratio** | Kills divided by deaths |
+| **Combat Kills/Deaths** | Not currently synchronized by the server addon bridge |
 
 ## 🔔 Notification Types
 
@@ -199,29 +197,13 @@ WoW/Screenshots/
 | **Solo play** | Show everything for full awareness |
 | **PvP focus** | Disable auto-hide, Lock UI |
 
-## 🎁 Hidden Features
-
-- **Double-click** title bar to minimize (planned)
-- **Shift-click** map to set personal waypoint (planned)
-- **Alt-click** player name to whisper (planned)
-- **Ctrl-click** to focus target (planned)
-
-## 🔮 Coming Soon
-
-- Heat maps for combat zones
-- Replay system
-- Guild leaderboards
-- Achievement integration
-- Custom alert sounds
-- Advanced statistics
-
 ---
 
 ## 📋 Checklist for New Users
 
 ```
 □ Addon installed in AddOns folder
-□ Ace3 libraries downloaded and placed
+□ Bundled libraries present in `CitySiege/Libs`
 □ Addon enabled at character select
 □ Welcome message appeared in chat
 □ Minimap button visible
@@ -230,7 +212,7 @@ WoW/Screenshots/
 □ All tabs accessible
 □ Map displays when siege active
 □ Notifications working
-□ Statistics tracking
+□ Siege participation tracking
 ```
 
 ---

--- a/ClientAddon/README.md
+++ b/ClientAddon/README.md
@@ -14,14 +14,13 @@ A comprehensive World of Warcraft 3.3.5 (WotLK) addon for the AzerothCore City S
 
 ### 📊 Siege Information & Statistics
 - View all active sieges across different cities
-- Real-time siege status updates
+- Periodic siege status updates from the server
 - Phase information and duration tracking
 - Participant counts (attackers vs defenders)
 - Personal statistics tracking:
   - Sieges participated in
   - Win/loss record
-  - Kill/death ratios
-  - Overall performance metrics
+  - Overall siege outcome summary
 
 ### 🎮 Command Interface
 - Easy-to-use button interface for all siege commands
@@ -75,7 +74,7 @@ These commands are executed through the addon but require appropriate permission
 - `/cs start [city]` - Start a siege in specified city
 - `/cs stop [city] [faction]` - Stop an active siege
 - `/cs cleanup [city]` - Clean up siege NPCs
-- `/cs info` - Display detailed siege information
+- `/cs info` - Display info for your currently selected siege NPC/playerbot
 - `/cs reload` - Reload server-side configuration
 
 ### Interface Navigation
@@ -192,16 +191,7 @@ The addon uses the following libraries (included):
 2. **Real-time Updates**: Position updates depend on server communication frequency
 3. **WoW 3.3.5 API**: Some modern addon features aren't available in this client version
 4. **Rotation**: Line rotation for waypoint paths is simplified due to API limitations
-
-## Future Enhancements
-
-Planned features for future versions:
-- 3D arrow indicators for objectives
-- Heat maps showing combat intensity
-- Replay functionality for completed sieges
-- Achievement integration
-- Cross-realm siege coordination
-- Mobile companion app data export
+5. **Statistics**: The addon currently tracks siege participation and outcomes, not full per-fight kill/death data
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Game Masters with `SEC_GAMEMASTER` security level have access to manual siege co
 - `.citysiege stop <cityname> <faction>` - Stop an active siege and declare a winner
 - `.citysiege cleanup [cityname]` - Force cleanup of siege creatures
 - `.citysiege status` - Display current siege events and module status
+- `.citysiege info` - Inspect the currently selected siege NPC or playerbot
 - `.citysiege testwaypoint` - Spawn a temporary test marker at your position (20 seconds)
 - `.citysiege waypoints <cityname>` - Toggle visualization of siege waypoint path
 - `.citysiege reload` - Reload configuration from file (Administrator only)
@@ -169,6 +170,19 @@ Displays the current status of the City Siege module and all active events.
   - Time remaining in the event
   - Number of creatures alive
 - Time until next automatic siege event
+
+#### `.citysiege info`
+Displays waypoint and target information for the currently selected siege NPC or playerbot.
+
+**Usage:**
+```
+.citysiege info
+```
+
+**Notes:**
+- Requires a siege NPC or siege playerbot to be selected first
+- Useful for diagnosing waypoint progress and stuck units
+- Reports the unit's current target and distance to that target
 
 #### `.citysiege testwaypoint`
 Spawns a temporary waypoint marker at your current position for 20 seconds. Use this to preview and test waypoint positions before adding them to the config file.
@@ -352,16 +366,16 @@ CitySiege.Creature.Horde.Defender      | Horde defender creature entry ID.      
 
 All creature entries are fully configurable:
 
-Setting                                      | Description                    | Default
----------------------------------------------|--------------------------------|--------
-CitySiege.Creature.Alliance.Minion           | Alliance attacker minion       | 17919
-CitySiege.Creature.Alliance.Elite            | Alliance attacker elite        | 17920
-CitySiege.Creature.Alliance.MiniBoss         | Alliance attacker mini-boss    | 17921
-CitySiege.Creature.Alliance.Leader           | Alliance attacker leader       | 17928
-CitySiege.Creature.Horde.Minion              | Horde attacker minion          | 17932
-CitySiege.Creature.Horde.Elite               | Horde attacker elite           | 17933
-CitySiege.Creature.Horde.MiniBoss            | Horde attacker mini-boss       | 17934
-CitySiege.Creature.Horde.Leader              | Horde attacker leader          | 17936
+Setting                                      | Description                                        | Default
+---------------------------------------------|----------------------------------------------------|--------
+CitySiege.Creature.Alliance.Minion           | Alliance attacker minion                           | 17919
+CitySiege.Creature.Alliance.Elite            | Alliance attacker elite                            | 17920
+CitySiege.Creature.Alliance.MiniBoss         | Alliance attacker mini-boss                        | 17921
+CitySiege.Creature.Horde.Minion              | Horde attacker minion                              | 17932
+CitySiege.Creature.Horde.Elite               | Horde attacker elite                               | 17933
+CitySiege.Creature.Horde.MiniBoss            | Horde attacker mini-boss                           | 17934
+
+Attacking leaders are chosen randomly from the opposing faction's city leader pool.
 
 ### Level Settings
 
@@ -449,9 +463,9 @@ CitySiege.RewardGoldPerLevel           | Additional gold per player level in cop
 
 Setting                                | Description                                           | Default
 ---------------------------------------|-------------------------------------------------------|--------
-CitySiege.Message.SiegeStart           | Message when siege begins (use %s for city name).     | \|cffff0000[City Siege]\|r The city of %s is under attack! Defenders are needed!
-CitySiege.Message.SiegeEnd             | Message when siege ends (use %s for city name).       | \|cff00ff00[City Siege]\|r The siege of %s has ended!
-CitySiege.Message.Reward               | Message sent to rewarded players (use %s for city).   | \|cff00ff00[City Siege]\|r You have been rewarded for defending %s!
+CitySiege.Message.SiegeStart           | Message when siege begins (use {CITYNAME}).           | \|cffff0000[City Siege]\|r The city of {CITYNAME} is under attack! Defenders are needed!
+CitySiege.Message.SiegeEnd             | Message when siege ends (use {CITYNAME}).             | \|cff00ff00[City Siege]\|r The siege of {CITYNAME} has ended!
+CitySiege.Message.Reward               | Base reward message ({CITYNAME}, {ACTION}).          | \|cff00ff00[City Siege]\|r You have been rewarded for {ACTION} {CITYNAME}!
 
 ### Creature Yells
 
@@ -475,7 +489,7 @@ To use custom creatures for siege events:
 All announcement messages and creature yells are configurable in `mod_city_siege.conf`:
 
 1. **Announcement Messages:**  
-   Edit `CitySiege.Message.SiegeStart`, `CitySiege.Message.SiegeEnd`, and `CitySiege.Message.Reward` to customize text. Use `%s` as a placeholder for the city name.
+  Edit `CitySiege.Message.SiegeStart`, `CitySiege.Message.SiegeEnd`, and `CitySiege.Message.Reward` to customize text. Use `{CITYNAME}` for the city name and `{ACTION}` in the reward message for defending/conquering.
 
 2. **Creature Yells:**  
    - `CitySiege.Yell.LeaderSpawn`: Message leaders yell when they spawn
@@ -566,7 +580,7 @@ Troubleshooting
 > Ensure that `CitySiege.Enabled = 1` and at least one city is enabled in the configuration file. Check server logs for any errors.
 
 > **No announcements appearing.**  
-> Verify `CitySiege.AnnounceRadius` is set correctly. If using a radius value, ensure players are within range of the city center. Set to 0 for world-wide announcements.
+> Verify `CitySiege.AnnounceRadius` is set correctly. This radius applies to siege start/end, countdown, battle start, and periodic status messages. Set to 0 for world-wide announcements.
 
 > **Configuration changes not taking effect.**  
 > Confirm the config file is in the correct location (`/path/to/server/etc/modules/mod_city_siege.conf`), check file permissions, and restart the worldserver after making changes.

--- a/conf/mod_city_siege.conf.dist
+++ b/conf/mod_city_siege.conf.dist
@@ -45,6 +45,7 @@ CitySiege.AllowMultipleCities = 0
 #
 #    CitySiege.AnnounceRadius
 #        Description: Radius (in yards) for announcing siege events to nearby players.
+#                     Applies to siege start/end, countdown, battle start, and status messages.
 #                     Set to 0 to announce to the entire world.
 #        Default:     1500
 CitySiege.AnnounceRadius = 1500
@@ -482,6 +483,7 @@ CitySiege.SpawnCount.Leaders = 1
 # These define which creature entries to use for siege forces.
 # Attacking faction leaders are now randomly selected from opposing faction city leader pools for variety.
 # Each siege will feature a different opposing faction leader leading the attack.
+# There are no separate config keys for individual attacker leader entries.
 #
 # Alliance attackers spawn Footmen, Knights, Riflemen, and a random Horde city leader.
 # Horde attackers spawn Grunts, Tauren Warriors, Headhunters, and a random Alliance city leader.
@@ -811,9 +813,10 @@ CitySiege.Message.SiegeEnd = "|cff00ff00[City Siege]|r The siege of {CITYNAME} h
 
 #
 #    CitySiege.Message.Reward
-#        Description: Message sent to players when they receive rewards. Use {CITYNAME} for city name.
-#        Default:     "|cff00ff00[City Siege]|r You have been rewarded for defending {CITYNAME}!"
-CitySiege.Message.Reward = "|cff00ff00[City Siege]|r You have been rewarded for defending {CITYNAME}!"
+#        Description: Base message sent to rewarded players.
+#                     Use {CITYNAME} for the city name and {ACTION} for defending/conquering.
+#        Default:     "|cff00ff00[City Siege]|r You have been rewarded for {ACTION} {CITYNAME}!"
+CitySiege.Message.Reward = "|cff00ff00[City Siege]|r You have been rewarded for {ACTION} {CITYNAME}!"
 
 ###############################################
 # Creature Yells

--- a/src/CitySiegeAPI.h
+++ b/src/CitySiegeAPI.h
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ */
+
+#ifndef MOD_CITY_SIEGE_API_H
+#define MOD_CITY_SIEGE_API_H
+
+#include "Define.h"
+#include <string>
+#include <vector>
+
+namespace CitySiegeAPI
+{
+    struct ActiveSiegeSnapshot
+    {
+        uint32 cityId = 0;
+        std::string cityName;
+        uint32 startTime = 0;
+        uint32 endTime = 0;
+        bool isActive = false;
+        bool cinematicPhase = false;
+        uint32 remainingSeconds = 0;
+        uint32 spawnedAttackers = 0;
+        uint32 spawnedDefenders = 0;
+        uint32 attackerBotCount = 0;
+        uint32 defenderBotCount = 0;
+    };
+
+    std::vector<ActiveSiegeSnapshot> GetActiveSieges();
+}
+
+#endif

--- a/src/CitySiegeAPI.h
+++ b/src/CitySiegeAPI.h
@@ -11,11 +11,19 @@
 #define MOD_CITY_SIEGE_API_H
 
 #include "Define.h"
+#include "ObjectGuid.h"
 #include <string>
 #include <vector>
 
 namespace CitySiegeAPI
 {
+    enum class SiegeParticipantRole : uint8
+    {
+        None = 0,
+        Attacker = 1,
+        Defender = 2,
+    };
+
     struct ActiveSiegeSnapshot
     {
         uint32 cityId = 0;
@@ -32,6 +40,7 @@ namespace CitySiegeAPI
     };
 
     std::vector<ActiveSiegeSnapshot> GetActiveSieges();
+    SiegeParticipantRole GetActiveCreatureRole(ObjectGuid const& creatureGuid);
 }
 
 #endif

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -1166,7 +1166,8 @@ void SpawnSiegeCreatures(SiegeEvent& event)
             creature->SetHover(false);
             creature->RemoveUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_FLYING | MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_HOVER);
             creature->SetReactState(REACT_PASSIVE);
-            creature->SetFaction(35);
+            creature->SetFaction(35); // Neutral during cinematic
+            creature->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
             
             // Prevent return to home position after combat
             creature->SetWalk(false);
@@ -1232,7 +1233,8 @@ void SpawnSiegeCreatures(SiegeEvent& event)
             creature->SetHover(false);
             creature->RemoveUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_FLYING | MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_HOVER);
             creature->SetReactState(REACT_PASSIVE);
-            creature->SetFaction(35);
+            creature->SetFaction(35); // Neutral during cinematic
+            creature->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
             
             // Prevent return to home position after combat
             creature->SetWalk(false);
@@ -1272,7 +1274,8 @@ void SpawnSiegeCreatures(SiegeEvent& event)
             creature->SetHover(false);
             creature->RemoveUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_FLYING | MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_HOVER);
             creature->SetReactState(REACT_PASSIVE);
-            creature->SetFaction(35);
+            creature->SetFaction(35); // Neutral during cinematic
+            creature->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
             
             // Prevent return to home position after combat
             creature->SetWalk(false);
@@ -1312,7 +1315,8 @@ void SpawnSiegeCreatures(SiegeEvent& event)
             creature->SetHover(false);
             creature->RemoveUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_FLYING | MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_HOVER);
             creature->SetReactState(REACT_PASSIVE);
-            creature->SetFaction(35);
+            creature->SetFaction(35); // Neutral during cinematic
+            creature->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
             
             // Prevent return to home position after combat
             creature->SetWalk(false);
@@ -1370,7 +1374,8 @@ void SpawnSiegeCreatures(SiegeEvent& event)
                 creature->SetHover(false);
                 creature->RemoveUnitMovementFlag(MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_FLYING | MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_HOVER);
                 creature->SetReactState(REACT_PASSIVE);
-                creature->SetFaction(35);
+                creature->SetFaction(35); // Neutral during cinematic
+                creature->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 
                 // Prevent return to home position after combat
                 creature->SetWalk(false);
@@ -3186,6 +3191,9 @@ void UpdateSiegeEvents(uint32 /*diff*/)
                 {
                     if (Creature* creature = map->GetCreature(guid))
                     {
+                        // End cinematic protection.
+                        creature->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+
                         // Set proper hostile faction: Horde attacks Alliance cities, Alliance attacks Horde cities
                         creature->SetFaction(isAllianceCity ? 83 : 84); // 83 = Horde, 84 = Alliance
                         
@@ -3272,6 +3280,9 @@ void UpdateSiegeEvents(uint32 /*diff*/)
                 {
                     if (Creature* creature = map->GetCreature(guid))
                     {
+                        // End cinematic protection.
+                        creature->RemoveUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
+
                         // Set proper defender faction (same as city faction)
                         creature->SetFaction(isAllianceCity ? 84 : 83); // 84 = Alliance, 83 = Horde
                         creature->SetReactState(REACT_AGGRESSIVE);

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -41,6 +41,7 @@
 #include "WeatherMgr.h"
 #include "MiscPackets.h"
 #include <vector>
+#include <array>
 #include <unordered_map>
 #include <string>
 #include <cmath>
@@ -360,6 +361,115 @@ static std::unordered_map<uint32, std::vector<ObjectGuid>> g_WaypointVisualizati
 
 // Forward declarations
 void DistributeRewards(const SiegeEvent& event, const CityData& city, int winningTeam = -1);
+void RestoreSiegeWeather(const CityData& city, SiegeEvent& event);
+void BroadcastSiegeDataToAddon(const SiegeEvent& event, const std::string& messageType,
+    const std::string& winner = "unknown");
+void DespawnSiegeCreatures(SiegeEvent& event);
+void DeactivatePlayerbotsFromSiege(SiegeEvent& event);
+
+bool IsAllianceCity(CityId cityId)
+{
+    return cityId <= CITY_EXODAR;
+}
+
+bool IsPlayerInAnnounceScope(Player* player, const CityData& city)
+{
+    return player && (g_AnnounceRadius == 0 ||
+        player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius);
+}
+
+std::string GetTeamName(int teamId)
+{
+    switch (teamId)
+    {
+        case 0:
+            return "Alliance";
+        case 1:
+            return "Horde";
+        default:
+            return "unknown";
+    }
+}
+
+void SendAddonMessageToPlayer(Player* player, const std::string& message)
+{
+    if (!player || !player->IsInWorld())
+        return;
+
+    WorldPacket data(SMSG_MESSAGECHAT, 2000);
+    data << uint8(CHAT_MSG_SYSTEM);
+    data << uint32(LANG_UNIVERSAL);
+    data << uint64(0);
+    data << uint32(0);
+    data << uint64(player->GetGUID().GetRawValue());
+
+    std::string fullMessage = "CitySiege\t" + message;
+    data << uint32(fullMessage.length() + 1);
+    data << fullMessage;
+    data << uint8(0);
+
+    player->GetSession()->SendPacket(&data);
+}
+
+void RespawnCityLeaderIfNeeded(const CityData& city, const SiegeEvent& event)
+{
+    Map* map = sMapMgr->FindMap(city.mapId, 0);
+    if (!map)
+        return;
+
+    Creature* existingLeader = nullptr;
+    if (event.cityLeaderGuid)
+        existingLeader = map->GetCreature(event.cityLeaderGuid);
+
+    if (!existingLeader)
+    {
+        std::list<Creature*> leaderList;
+        CitySiege::CreatureEntryCheck check(city.targetLeaderEntry);
+        CitySiege::SimpleCreatureListSearcher<CitySiege::CreatureEntryCheck> searcher(leaderList, check);
+        Cell::VisitObjects(city.leaderX, city.leaderY, map, searcher, 100.0f);
+
+        for (Creature* leader : leaderList)
+        {
+            if (leader)
+            {
+                existingLeader = leader;
+                break;
+            }
+        }
+    }
+
+    if (existingLeader && !existingLeader->IsAlive())
+    {
+        existingLeader->Respawn();
+
+        if (g_DebugMode)
+        {
+            LOG_INFO("server.loading", "[City Siege] Respawned city leader {} (entry {})",
+                     existingLeader->GetName(), city.targetLeaderEntry);
+        }
+    }
+}
+
+void FinalizeSiegeCleanup(SiegeEvent& event, const std::string& winnerForAddon,
+    bool respawnLeader = true)
+{
+    const CityData& city = g_Cities[event.cityId];
+
+    event.isActive = false;
+    DespawnSiegeCreatures(event);
+    BroadcastSiegeDataToAddon(event, "END", winnerForAddon);
+    RestoreSiegeWeather(city, event);
+
+    if (respawnLeader)
+        RespawnCityLeaderIfNeeded(city, event);
+
+    DeactivatePlayerbotsFromSiege(event);
+
+    event.creatureWaypointProgress.clear();
+    event.deadCreatures.clear();
+    event.deadBots.clear();
+    event.activeRPScript.clear();
+}
 
 /**
  * @brief Sets siege weather for a city during RP phase
@@ -762,24 +872,28 @@ void AnnounceSiege(const CityData& city, bool isStart)
 }
 
 /**
- * @brief Broadcasts siege data to clients via addon messages
- * @param event The siege event to broadcast
- * @param messageType Type of message (START, UPDATE, END, POSITION)
+ * @brief Sends siege data to a specific player's addon.
+ * @param player The target player.
+ * @param event The siege event to serialize.
+ * @param messageType Type of message (START, UPDATE, END).
+ * @param winner Winner identifier for END messages.
  */
-void BroadcastSiegeDataToAddon(const SiegeEvent& event, const std::string& messageType)
+void SendSiegeDataToPlayer(Player* player, const SiegeEvent& event,
+    const std::string& messageType, const std::string& winner = "unknown")
 {
+    if (!player)
+        return;
+
     const CityData& city = g_Cities[event.cityId];
     Map* map = sMapMgr->FindMap(city.mapId, 0);
     if (!map)
         return;
 
     std::ostringstream ss;
-    
+
     if (messageType == "START")
     {
-        // Format: START:cityId:faction:spawnX:spawnY:spawnZ:leaderX:leaderY:leaderZ:centerX:centerY:centerZ
-        bool isAllianceCity = (event.cityId <= CITY_EXODAR);
-        std::string attackingFaction = isAllianceCity ? "Horde" : "Alliance";
+        std::string attackingFaction = IsAllianceCity(event.cityId) ? "Horde" : "Alliance";
         ss << "START:" << static_cast<uint32>(event.cityId) << ":" << attackingFaction
            << ":" << std::fixed << std::setprecision(2)
            << city.spawnX << ":" << city.spawnY << ":" << city.spawnZ
@@ -788,55 +902,58 @@ void BroadcastSiegeDataToAddon(const SiegeEvent& event, const std::string& messa
     }
     else if (messageType == "UPDATE")
     {
-        // Get leader health if available
         float leaderHealthPct = 0.0f;
         if (event.cityLeaderGuid)
         {
             if (Creature* leader = map->GetCreature(event.cityLeaderGuid))
             {
                 if (leader->IsAlive())
-                {
                     leaderHealthPct = leader->GetHealthPct();
-                }
             }
         }
-        
+
         uint32 attackerCount = event.spawnedCreatures.size();
         uint32 defenderCount = event.spawnedDefenders.size();
         uint32 elapsed = time(nullptr) - event.startTime;
         uint32 remaining = event.endTime > time(nullptr) ? event.endTime - time(nullptr) : 0;
-        
-        // Determine phase
+
         uint32 phase = 1;
         if (!event.cinematicPhase)
         {
             uint32 duration = event.endTime - event.startTime;
-            if (elapsed > duration * 0.75f) phase = 4;
-            else if (elapsed > duration * 0.5f) phase = 3;
-            else if (elapsed > duration * 0.25f) phase = 2;
+            if (elapsed > duration * 0.75f)
+                phase = 4;
+            else if (elapsed > duration * 0.5f)
+                phase = 3;
+            else if (elapsed > duration * 0.25f)
+                phase = 2;
         }
-        
-        // Format: UPDATE:cityId:phase:attackers:defenders:elapsed:remaining:leaderHealth
-        ss << "UPDATE:" << static_cast<uint32>(event.cityId) << ":" << phase 
-           << ":" << attackerCount << ":" << defenderCount 
+
+        ss << "UPDATE:" << static_cast<uint32>(event.cityId) << ":" << phase
+           << ":" << attackerCount << ":" << defenderCount
            << ":" << elapsed << ":" << remaining
            << ":" << std::fixed << std::setprecision(1) << leaderHealthPct;
-        
-        // Only send waypoint data (removed NPC/player positions to reduce packet size)
+
         ss << ":WP:" << city.waypoints.size();
         for (const auto& wp : city.waypoints)
-        {
             ss << ":" << std::fixed << std::setprecision(2) << wp.x << ":" << wp.y << ":" << wp.z;
-        }
     }
     else if (messageType == "END")
     {
-        // Format: END:cityId:winner
-        ss << "END:" << static_cast<uint32>(event.cityId) << ":unknown";
+        ss << "END:" << static_cast<uint32>(event.cityId) << ":" << winner;
     }
-    
-    std::string message = ss.str();
-    
+
+    SendAddonMessageToPlayer(player, ss.str());
+}
+
+/**
+ * @brief Broadcasts siege data to clients via addon messages
+ * @param event The siege event to broadcast
+ * @param messageType Type of message (START, UPDATE, END, POSITION)
+ */
+void BroadcastSiegeDataToAddon(const SiegeEvent& event, const std::string& messageType,
+    const std::string& winner)
+{
     // Send SILENTLY to ALL online players (addon users will intercept it)
     std::shared_lock<std::shared_mutex> lock(*HashMapHolder<Player>::GetLock());
     HashMapHolder<Player>::MapType const& players = ObjectAccessor::GetPlayers();
@@ -846,23 +963,7 @@ void BroadcastSiegeDataToAddon(const SiegeEvent& event, const std::string& messa
         if (Player* player = pair.second)
         {
             if (player->IsInWorld())
-            {
-                // Send as CHAT_MSG_SYSTEM with CitySiege prefix (addon will filter it)
-                WorldPacket data(SMSG_MESSAGECHAT, 2000);
-                data << uint8(CHAT_MSG_SYSTEM);
-                data << uint32(LANG_UNIVERSAL);
-                data << uint64(0);
-                data << uint32(0);
-                data << uint64(player->GetGUID().GetRawValue());
-                
-                // Use tab separator that addon expects
-                std::string fullMessage = "CitySiege\t" + message;
-                data << uint32(fullMessage.length() + 1);
-                data << fullMessage;
-                data << uint8(0);
-                
-                player->GetSession()->SendPacket(&data);
-            }
+                SendSiegeDataToPlayer(player, event, messageType, winner);
         }
     }
 }
@@ -898,23 +999,7 @@ void SendMapDataToPlayer(Player* player, CityId cityId)
     ss << ":LEADER:" << std::fixed << std::setprecision(2) 
        << city.leaderX << ":" << city.leaderY << ":" << city.leaderZ;
     
-    std::string message = ss.str();
-    
-    // Send as CHAT_MSG_SYSTEM with CitySiege prefix (addon will filter it)
-    WorldPacket data(SMSG_MESSAGECHAT, 2000);
-    data << uint8(CHAT_MSG_SYSTEM);
-    data << uint32(LANG_UNIVERSAL);
-    data << uint64(0);
-    data << uint32(0);
-    data << uint64(player->GetGUID().GetRawValue());
-    
-    // Use tab separator that addon expects
-    std::string fullMessage = "CitySiege\t" + message;
-    data << uint32(fullMessage.length() + 1);
-    data << fullMessage;
-    data << uint8(0);
-    
-    player->GetSession()->SendPacket(&data);
+    SendAddonMessageToPlayer(player, ss.str());
 }
 
 /**
@@ -1910,14 +1995,15 @@ void DeactivatePlayerbotsFromSiege(SiegeEvent& event)
         if (!bot || !bot->IsInWorld())
             continue;
             
-        // Safety checks before teleporting
         if (!bot->IsAlive())
         {
+            bot->ResurrectPlayer(1.0f);
+            bot->SpawnCorpseBones();
+
             if (g_DebugMode)
             {
-                LOG_INFO("server.loading", "[City Siege] Skipping return for dead bot {}", bot->GetName());
+                LOG_INFO("server.loading", "[City Siege] Resurrected bot {} before returning it from siege", bot->GetName());
             }
-            continue;
         }
         
         // Don't teleport if bot is in a dungeon, raid, arena, or battleground
@@ -2212,7 +2298,7 @@ void StartSiegeEvent(int targetCityId = -1)
             {
                 if (Player* player = itr->GetSource())
                 {
-                    if (player->GetDistance(city->centerX, city->centerY, city->centerZ) <= g_AnnounceRadius)
+                    if (IsPlayerInAnnounceScope(player, *city))
                     {
                         player->SendDirectMessage(WorldPackets::Misc::PlayMusic(g_RPMusicId).Write());
                     }
@@ -2244,11 +2330,11 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
     }
 
     const CityData& city = g_Cities[event.cityId];
-    event.isActive = false;
+    int defendingTeam = IsAllianceCity(event.cityId) ? 0 : 1;
+    int attackingTeam = IsAllianceCity(event.cityId) ? 1 : 0;
 
     // Check if defenders won (city leader still alive)
     bool defendersWon = false;
-    bool leaderKilled = false;
     Map* map = sMapMgr->FindMap(city.mapId, 0);
     
     if (map && event.cityLeaderGuid)
@@ -2268,8 +2354,6 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
         }
         else
         {
-            leaderKilled = true;
-            
             if (g_DebugMode)
             {
                 if (cityLeader)
@@ -2299,8 +2383,7 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
     // If winningTeam was explicitly passed (GM command), override the result
     if (winningTeam != -1)
     {
-        defendersWon = false;
-        leaderKilled = true;
+        defendersWon = (winningTeam == defendingTeam);
         
         if (g_DebugMode)
         {
@@ -2308,32 +2391,20 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
         }
     }
 
-    DespawnSiegeCreatures(event);
+    int resolvedWinningTeam = defendersWon ? defendingTeam : attackingTeam;
+    std::string resolvedWinningFaction = GetTeamName(resolvedWinningTeam);
+
     AnnounceSiege(city, false);
-    
-    // Broadcast siege end to addons
-    BroadcastSiegeDataToAddon(event, "END");
-
-    // Restore original weather
-    RestoreSiegeWeather(city, event);
-
-    // Determine which faction owns the city
-    bool isAllianceCity = (event.cityId == CITY_STORMWIND || event.cityId == CITY_IRONFORGE || 
-                          event.cityId == CITY_DARNASSUS || event.cityId == CITY_EXODAR);
 
     // Announce the winner (using same logic as AnnounceSiege)
     std::string winnerAnnouncement;
     if (defendersWon)
     {
-        // Defenders won - announce defending faction victory
-        std::string defendingFaction = isAllianceCity ? "Alliance" : "Horde";
-        winnerAnnouncement = "|cff00ff00[City Siege]|r The " + defendingFaction + " has successfully defended " + city.name + "! Victory to the defenders!";
+        winnerAnnouncement = "|cff00ff00[City Siege]|r The " + resolvedWinningFaction + " has successfully defended " + city.name + "! Victory to the defenders!";
     }
     else
     {
-        // Attackers won (city leader killed) - announce attacking faction victory
-        std::string attackingFaction = isAllianceCity ? "Horde" : "Alliance";
-        winnerAnnouncement = "|cffff0000[City Siege]|r The " + attackingFaction + " has conquered " + city.name + "! The city has fallen!";
+        winnerAnnouncement = "|cffff0000[City Siege]|r The " + resolvedWinningFaction + " has conquered " + city.name + "! The city has fallen!";
     }
     
     // Send announcement (same logic as AnnounceSiege)
@@ -2353,7 +2424,7 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
             {
                 if (Player* player = itr->GetSource())
                 {
-                    if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
+                    if (IsPlayerInAnnounceScope(player, city))
                     {
                         ChatHandler(player->GetSession()).PSendSysMessage(winnerAnnouncement.c_str());
                     }
@@ -2375,13 +2446,12 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
         {
             if (defendersWon && g_VictoryMusicId > 0)
             {
-                // Send victory music to players within announce radius
                 Map::PlayerList const& players = map->GetPlayers();
                 for (auto itr = players.begin(); itr != players.end(); ++itr)
                 {
                     if (Player* player = itr->GetSource())
                     {
-                        if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
+                        if (IsPlayerInAnnounceScope(player, city))
                         {
                             player->SendDirectMessage(WorldPackets::Misc::PlayMusic(g_VictoryMusicId).Write());
                         }
@@ -2395,13 +2465,12 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
             }
             else if (!defendersWon && g_DefeatMusicId > 0)
             {
-                // Send defeat music to players within announce radius
                 Map::PlayerList const& players = map->GetPlayers();
                 for (auto itr = players.begin(); itr != players.end(); ++itr)
                 {
                     if (Player* player = itr->GetSource())
                     {
-                        if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
+                        if (IsPlayerInAnnounceScope(player, city))
                         {
                             player->SendDirectMessage(WorldPackets::Misc::PlayMusic(g_DefeatMusicId).Write());
                         }
@@ -2417,69 +2486,9 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
     }
 
     if (g_RewardOnDefense)
-    {
-        if (defendersWon)
-        {
-            // Defenders won - reward defending faction (0 = Alliance, 1 = Horde)
-            int winningTeam = isAllianceCity ? 0 : 1;
-            DistributeRewards(event, city, winningTeam);
-        }
-        else
-        {
-            // Attackers won (city leader killed) - reward attacking faction
-            int winningTeam = isAllianceCity ? 1 : 0; // Opposite faction
-            DistributeRewards(event, city, winningTeam);
-        }
-    }
+        DistributeRewards(event, city, resolvedWinningTeam);
 
-    // Respawn city leader if they were killed during the siege
-    if (leaderKilled && map)
-    {
-        // Search around the leader's throne coordinates directly
-        std::list<Creature*> leaderList;
-        CitySiege::CreatureEntryCheck check(city.targetLeaderEntry);
-        CitySiege::SimpleCreatureListSearcher<CitySiege::CreatureEntryCheck> searcher(leaderList, check);
-        Cell::VisitObjects(city.leaderX, city.leaderY, map, searcher, 100.0f);
-        
-        Creature* existingLeader = nullptr;
-        
-        // Find the leader at the throne
-        for (Creature* leader : leaderList)
-        {
-            if (leader)
-            {
-                existingLeader = leader;
-                break;
-            }
-        }
-        
-        // Respawn the leader
-        if (existingLeader)
-        {
-            if (!existingLeader->IsAlive())
-            {
-                existingLeader->Respawn();
-                
-                if (g_DebugMode)
-                {
-                    LOG_INFO("server.loading", "[City Siege] Respawned city leader {} (entry {}) at {}", 
-                             city.name, city.targetLeaderEntry, existingLeader->GetName());
-                }
-            }
-        }
-        else
-        {
-            // Leader doesn't exist in world - log warning
-            if (g_DebugMode)
-            {
-                LOG_WARN("server.loading", "[City Siege] Could not find city leader {} (entry {}) to respawn!", 
-                         city.name, city.targetLeaderEntry);
-            }
-        }
-    }
-
-    // Deactivate playerbots from siege
-    DeactivatePlayerbotsFromSiege(event);
+    FinalizeSiegeCleanup(event, resolvedWinningFaction);
 
     if (g_DebugMode)
     {
@@ -2516,11 +2525,13 @@ void DistributeRewards(const SiegeEvent& /*event*/, const CityData& city, int wi
             }
             
             // Check if player is in range and appropriate level
-            if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius &&
+            if (IsPlayerInAnnounceScope(player, city) &&
                 player->GetLevel() >= g_MinimumLevel)
             {
                 uint32 honorAwarded = 0;
                 uint32 goldAwarded = 0;
+                bool defendingTeamWon = (winningTeam == (IsAllianceCity(city.id) ? 0 : 1));
+                const char* victoryAction = defendingTeamWon ? "defending" : "conquering";
                 
                 // Award honor
                 if (g_RewardHonor > 0)
@@ -2548,28 +2559,28 @@ void DistributeRewards(const SiegeEvent& /*event*/, const CityData& city, int wi
                     if (goldCoins > 0)
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%u Honor|r and |cffFFD700%ug %us %uc|r",
-                            city.name.c_str(), honorAwarded, goldCoins, silverCoins, copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%ug %us %uc|r",
+                            victoryAction, city.name.c_str(), honorAwarded, goldCoins, silverCoins, copperCoins);
                     }
                     else if (silverCoins > 0)
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%u Honor|r and |cffFFD700%us %uc|r",
-                            city.name.c_str(), honorAwarded, silverCoins, copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%us %uc|r",
+                            victoryAction, city.name.c_str(), honorAwarded, silverCoins, copperCoins);
                     }
                     else
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%u Honor|r and |cffFFD700%uc|r",
-                            city.name.c_str(), honorAwarded, copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%uc|r",
+                            victoryAction, city.name.c_str(), honorAwarded, copperCoins);
                     }
                 }
                 else if (honorAwarded > 0)
                 {
                     // Only honor
                     snprintf(rewardMsg, sizeof(rewardMsg), 
-                        "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%u Honor|r",
-                        city.name.c_str(), honorAwarded);
+                        "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r",
+                        victoryAction, city.name.c_str(), honorAwarded);
                 }
                 else if (goldAwarded > 0)
                 {
@@ -2577,28 +2588,28 @@ void DistributeRewards(const SiegeEvent& /*event*/, const CityData& city, int wi
                     if (goldCoins > 0)
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%ug %us %uc|r",
-                            city.name.c_str(), goldCoins, silverCoins, copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%ug %us %uc|r",
+                            victoryAction, city.name.c_str(), goldCoins, silverCoins, copperCoins);
                     }
                     else if (silverCoins > 0)
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%us %uc|r",
-                            city.name.c_str(), silverCoins, copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%us %uc|r",
+                            victoryAction, city.name.c_str(), silverCoins, copperCoins);
                     }
                     else
                     {
                         snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for defending %s! Received: |cffFFD700%uc|r",
-                            city.name.c_str(), copperCoins);
+                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%uc|r",
+                            victoryAction, city.name.c_str(), copperCoins);
                     }
                 }
                 else
                 {
                     // No rewards configured
                     snprintf(rewardMsg, sizeof(rewardMsg), 
-                        "|cff00ff00[City Siege]|r You have been rewarded for defending %s!",
-                        city.name.c_str());
+                        "|cff00ff00[City Siege]|r You have been rewarded for %s %s!",
+                        victoryAction, city.name.c_str());
                 }
                 
                 ChatHandler(player->GetSession()).PSendSysMessage(rewardMsg);
@@ -3108,7 +3119,7 @@ void UpdateSiegeEvents(uint32 /*diff*/)
                     {
                         if (Player* player = itr->GetSource())
                         {
-                            if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
+                            if (IsPlayerInAnnounceScope(player, city))
                             {
                                 player->SendDirectMessage(WorldPackets::Misc::PlayMusic(g_CombatMusicId).Write());
                             }
@@ -4282,9 +4293,7 @@ public:
         for (auto& event : g_ActiveSieges)
         {
             if (event.isActive)
-            {
-                DespawnSiegeCreatures(event);
-            }
+                FinalizeSiegeCleanup(event, "shutdown", false);
         }
         g_ActiveSieges.clear();
 
@@ -4468,59 +4477,9 @@ public:
             {
                 found = true;
                 
-                const CityData& city = g_Cities[cityId];
-                
                 // Determine winning team (0 = Alliance, 1 = Horde)
                 int winningTeam = allianceWins ? 0 : 1;
-                
-                // Announce winner to world or in range
-                std::string winnerAnnouncement;
-                std::string winningFaction = allianceWins ? "Alliance" : "Horde";
-                bool isAllianceCity = (cityId == CITY_STORMWIND || cityId == CITY_IRONFORGE || 
-                                      cityId == CITY_DARNASSUS || cityId == CITY_EXODAR);
-                
-                // Check if winners were defenders or attackers
-                bool defendersWon = (allianceWins && isAllianceCity) || (!allianceWins && !isAllianceCity);
-                
-                if (defendersWon)
-                {
-                    winnerAnnouncement = "|cff00ff00[City Siege]|r The " + winningFaction + " has successfully defended " + city.name + "! Victory to the defenders!";
-                }
-                else
-                {
-                    winnerAnnouncement = "|cffff0000[City Siege]|r The " + winningFaction + " has conquered " + city.name + "! The city has fallen!";
-                }
-                
-                // Announce to world or in range
-                if (g_AnnounceRadius == 0)
-                {
-                    sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, winnerAnnouncement);
-                }
-                else
-                {
-                    Map* map = sMapMgr->FindMap(city.mapId, 0);
-                    if (map)
-                    {
-                        Map::PlayerList const& players = map->GetPlayers();
-                        for (auto itr = players.begin(); itr != players.end(); ++itr)
-                        {
-                            if (Player* player = itr->GetSource())
-                            {
-                                if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
-                                {
-                                    ChatHandler(player->GetSession()).PSendSysMessage(winnerAnnouncement.c_str());
-                                }
-                            }
-                        }
-                    }
-                }
-                
-                // Distribute rewards to winning faction's players
-                DistributeRewards(event, city, winningTeam);
-                                
-                // Clean up
-                DespawnSiegeCreatures(event);
-                event.isActive = false;
+                EndSiegeEvent(event, winningTeam);
                 
                 break;
             }
@@ -4574,8 +4533,7 @@ public:
         {
             if (cityId == -1 || event.cityId == cityId)
             {
-                DespawnSiegeCreatures(event);
-                event.isActive = false;
+                FinalizeSiegeCleanup(event, "cleanup");
                 handler->PSendSysMessage(("Cleaned up siege creatures in " + g_Cities[event.cityId].name).c_str());
                 cleanedCount++;
 
@@ -4836,7 +4794,6 @@ public:
         // Visualize each waypoint
         handler->PSendSysMessage(("City has " + std::to_string(city.waypoints.size()) + " waypoints configured.").c_str());
         
-        int spawnedWaypoints = 0;
         int failedWaypoints = 0;
         
         for (size_t i = 0; i < city.waypoints.size(); ++i)
@@ -4863,7 +4820,6 @@ public:
                 marker->SetUnitFlag(UNIT_FLAG_NON_ATTACKABLE);
                 marker->SetUnitFlag(UNIT_FLAG_NOT_SELECTABLE);
                 visualizations.push_back(marker->GetGUID());
-                spawnedWaypoints++;
                 
                 // Format coordinates properly
                 char waypointMsg[256];
@@ -4977,7 +4933,6 @@ public:
 
         // Find which siege this unit belongs to
         SiegeEvent* activeSiege = nullptr;
-        bool isAttacker = false;
         bool isDefender = false;
 
         for (auto& event : g_ActiveSieges)
@@ -4992,7 +4947,6 @@ public:
                 {
                     if (guid == unitGuid)
                     {
-                        isAttacker = true;
                         activeSiege = &event;
                         break;
                     }
@@ -5004,7 +4958,6 @@ public:
                 {
                     if (guid == unitGuid)
                     {
-                        isAttacker = true;
                         activeSiege = &event;
                         break;
                     }
@@ -5200,16 +5153,27 @@ public:
             return false;
         }
 
-        // If no city ID provided, broadcast all active sieges
+        // If no city ID provided, sync all cities to this player.
         if (!cityIdArg)
         {
+            std::array<bool, CITY_MAX> hasActiveSiege = {};
+
             for (auto& event : g_ActiveSieges)
             {
                 if (event.isActive)
                 {
-                    BroadcastSiegeDataToAddon(event, "UPDATE");
+                    hasActiveSiege[event.cityId] = true;
+                    SendSiegeDataToPlayer(player, event, "START");
+                    SendSiegeDataToPlayer(player, event, "UPDATE");
                 }
             }
+
+            for (uint32 cityId = 0; cityId < CITY_MAX; ++cityId)
+            {
+                if (!hasActiveSiege[cityId])
+                    SendAddonMessageToPlayer(player, "END:" + std::to_string(cityId) + ":none");
+            }
+
             return true;
         }
 
@@ -5224,19 +5188,13 @@ public:
         {
             if (event.isActive && event.cityId == static_cast<int>(cityId))
             {
-                BroadcastSiegeDataToAddon(event, "UPDATE");
+                SendSiegeDataToPlayer(player, event, "START");
+                SendSiegeDataToPlayer(player, event, "UPDATE");
                 return true;
             }
         }
 
-        // City not under siege - send empty/end status
-        WorldPacket data(SMSG_MESSAGECHAT, 200);
-        data << uint8(CHAT_MSG_SYSTEM);
-        data << uint32(LANG_UNIVERSAL);
-        data << uint64(0);
-        data << uint32(0);
-        data << uint64(0);
-        data << uint32(0);
+        SendAddonMessageToPlayer(player, "END:" + std::to_string(cityId) + ":none");
         
         return true;
     }
@@ -5321,7 +5279,7 @@ public:
         snprintf(msg, sizeof(msg), 
             "|cff00ff00[City Siege]|r Distance to %s center: %.1f yards\nCenter coords: (%.1f, %.1f, %.1f)\nAnnounce radius: %u yards\n%s",
             city.name.c_str(), distance, city.centerX, city.centerY, city.centerZ, g_AnnounceRadius,
-            distance <= g_AnnounceRadius ? "|cff00ff00You ARE in range|r" : "|cffff0000You are OUT OF RANGE|r");
+            g_AnnounceRadius == 0 || distance <= g_AnnounceRadius ? "|cff00ff00You ARE in range|r" : "|cffff0000You are OUT OF RANGE|r");
         handler->PSendSysMessage(msg);
 
         return true;

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -383,6 +383,26 @@ namespace CitySiegeAPI
 
         return snapshots;
     }
+
+    SiegeParticipantRole GetActiveCreatureRole(ObjectGuid const& creatureGuid)
+    {
+        if (creatureGuid.IsEmpty())
+            return SiegeParticipantRole::None;
+
+        for (SiegeEvent const& event : g_ActiveSieges)
+        {
+            if (!event.isActive)
+                continue;
+
+            if (std::find(event.spawnedCreatures.begin(), event.spawnedCreatures.end(), creatureGuid) != event.spawnedCreatures.end())
+                return SiegeParticipantRole::Attacker;
+
+            if (std::find(event.spawnedDefenders.begin(), event.spawnedDefenders.end(), creatureGuid) != event.spawnedDefenders.end())
+                return SiegeParticipantRole::Defender;
+        }
+
+        return SiegeParticipantRole::None;
+    }
 }
 
 // Waypoint visualization tracking

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -40,6 +40,7 @@
 #include "Weather.h"
 #include "WeatherMgr.h"
 #include "MiscPackets.h"
+#include "CitySiegeAPI.h"
 #include <vector>
 #include <array>
 #include <unordered_map>
@@ -351,6 +352,39 @@ struct SiegeEvent
 // Active siege events
 static std::vector<SiegeEvent> g_ActiveSieges;
 static uint32 g_NextSiegeTime = 0;
+
+namespace CitySiegeAPI
+{
+    std::vector<ActiveSiegeSnapshot> GetActiveSieges()
+    {
+        std::vector<ActiveSiegeSnapshot> snapshots;
+        snapshots.reserve(g_ActiveSieges.size());
+
+        uint32 const currentTime = static_cast<uint32>(time(nullptr));
+        for (SiegeEvent const& event : g_ActiveSieges)
+        {
+            CityData const& city = g_Cities[event.cityId];
+
+            ActiveSiegeSnapshot snapshot;
+            snapshot.cityId = static_cast<uint32>(event.cityId);
+            snapshot.cityName = city.name;
+            snapshot.startTime = event.startTime;
+            snapshot.endTime = event.endTime;
+            snapshot.isActive = event.isActive;
+            snapshot.cinematicPhase = event.cinematicPhase;
+            snapshot.remainingSeconds = event.endTime > currentTime ?
+                event.endTime - currentTime : 0;
+            snapshot.spawnedAttackers = event.spawnedCreatures.size();
+            snapshot.spawnedDefenders = event.spawnedDefenders.size();
+            snapshot.attackerBotCount = event.attackerBots.size();
+            snapshot.defenderBotCount = event.defenderBots.size();
+
+            snapshots.push_back(std::move(snapshot));
+        }
+
+        return snapshots;
+    }
+}
 
 // Waypoint visualization tracking
 static std::unordered_map<uint32, std::vector<ObjectGuid>> g_WaypointVisualizations; // cityId -> vector of creature GUIDs

--- a/src/mod-city-siege.cpp
+++ b/src/mod-city-siege.cpp
@@ -48,6 +48,7 @@
 #include <cmath>
 #include <algorithm>
 #include <iomanip>
+#include <sstream>
 
 // Conditional include for playerbots module
 #ifdef MOD_PLAYERBOTS
@@ -196,7 +197,7 @@ static uint32 g_RewardGoldPerLevel = 5000; // 0.5 gold per level in copper
 // Announcement messages
 static std::string g_MessageSiegeStart = "|cffff0000[City Siege]|r The city of {CITYNAME} is under attack! Defenders are needed!";
 static std::string g_MessageSiegeEnd = "|cff00ff00[City Siege]|r The siege of {CITYNAME} has ended!";
-static std::string g_MessageReward = "|cff00ff00[City Siege]|r You have been rewarded for defending {CITYNAME}!";
+static std::string g_MessageReward = "|cff00ff00[City Siege]|r You have been rewarded for {ACTION} {CITYNAME}!";
 
 // Leader spawn yell
 static std::string g_YellLeaderSpawn = "This city will fall before our might!";
@@ -340,9 +341,7 @@ struct SiegeEvent
     };
     std::vector<RespawnData> deadCreatures; // Creatures waiting to respawn
 
-    // Weather storage for siege weather override
-    WeatherState originalWeatherType; // Store original weather type
-    float originalWeatherGrade; // Store original weather grade
+    // Weather override state
     bool weatherOverridden; // Track if weather was overridden for this siege
     
     // Addon communication tracking
@@ -422,6 +421,40 @@ std::string GetTeamName(int teamId)
             return "Horde";
         default:
             return "unknown";
+    }
+}
+
+std::string ReplacePlaceholder(std::string message, std::string const& placeholder,
+    std::string const& value)
+{
+    size_t pos = 0;
+    while ((pos = message.find(placeholder, pos)) != std::string::npos)
+    {
+        message.replace(pos, placeholder.length(), value);
+        pos += value.length();
+    }
+
+    return message;
+}
+
+void SendSiegeScopedMessage(CityData const& city, std::string const& message)
+{
+    if (g_AnnounceRadius == 0)
+    {
+        sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, message);
+        return;
+    }
+
+    Map* map = sMapMgr->FindMap(city.mapId, 0);
+    if (!map)
+        return;
+
+    Map::PlayerList const& players = map->GetPlayers();
+    for (auto itr = players.begin(); itr != players.end(); ++itr)
+    {
+        if (Player* player = itr->GetSource())
+            if (IsPlayerInAnnounceScope(player, city))
+                ChatHandler(player->GetSession()).PSendSysMessage(message.c_str());
     }
 }
 
@@ -522,11 +555,8 @@ void SetSiegeWeather(const CityData& city, SiegeEvent& event)
     // Get the zone ID from the city center coordinates
     uint32 zoneId = map->GetZoneId(0, city.centerX, city.centerY, city.centerZ);
 
-    // Store original weather state
-    // Note: Weather::GetWeatherState() and Weather::GetGrade() are private methods
-    // Since we can't access them from a module, we'll restore to fine weather
-    event.originalWeatherType = WEATHER_STATE_FINE;
-    event.originalWeatherGrade = 0.0f;
+    // Prime the default weather cache so we can restore the zone's default weather later.
+    map->GetOrGenerateZoneDefaultWeather(zoneId);
     event.weatherOverridden = true;
 
     // Set siege weather
@@ -556,13 +586,24 @@ void RestoreSiegeWeather(const CityData& city, SiegeEvent& event)
     // Get the zone ID from the city center coordinates
     uint32 zoneId = map->GetZoneId(0, city.centerX, city.centerY, city.centerZ);
 
-    // Restore original weather
-    map->SetZoneWeather(zoneId, event.originalWeatherType, event.originalWeatherGrade);
+    // Clear the override and restore the zone's default/generated weather.
+    map->SetZoneWeather(zoneId, WEATHER_STATE_FINE, 0.0f);
+
+    if (Weather* defaultWeather = map->GetOrGenerateZoneDefaultWeather(zoneId))
+    {
+        Map::PlayerList const& players = map->GetPlayers();
+        for (auto itr = players.begin(); itr != players.end(); ++itr)
+        {
+            if (Player* player = itr->GetSource())
+                if (player->GetZoneId() == zoneId)
+                    defaultWeather->SendWeatherUpdateToPlayer(player);
+        }
+    }
 
     if (g_DebugMode)
     {
-        LOG_INFO("server.loading", "[City Siege] Restored original weather for {} (zone {}): type={}, grade={:.2f}",
-                 city.name, zoneId, static_cast<uint32>(event.originalWeatherType), event.originalWeatherGrade);
+        LOG_INFO("server.loading", "[City Siege] Restored default weather for {} (zone {})",
+                 city.name, zoneId);
     }
 
     event.weatherOverridden = false;
@@ -655,7 +696,7 @@ void LoadCitySiegeConfiguration()
     g_MessageSiegeEnd = sConfigMgr->GetOption<std::string>("CitySiege.Message.SiegeEnd", 
         "|cff00ff00[City Siege]|r The siege of {CITYNAME} has ended!");
     g_MessageReward = sConfigMgr->GetOption<std::string>("CitySiege.Message.Reward", 
-        "|cff00ff00[City Siege]|r You have been rewarded for defending {CITYNAME}!");
+        "|cff00ff00[City Siege]|r You have been rewarded for {ACTION} {CITYNAME}!");
     
     // Yells
     g_YellLeaderSpawn = sConfigMgr->GetOption<std::string>("CitySiege.Yell.LeaderSpawn", 
@@ -854,50 +895,9 @@ CityData* SelectRandomCity()
  */
 void AnnounceSiege(const CityData& city, bool isStart)
 {
-    std::string message;
-    if (isStart)
-    {
-        message = g_MessageSiegeStart;
-        size_t pos = message.find("{CITYNAME}");
-        if (pos != std::string::npos)
-        {
-            message.replace(pos, 10, city.name);
-        }
-    }
-    else
-    {
-        message = g_MessageSiegeEnd;
-        size_t pos = message.find("{CITYNAME}");
-        if (pos != std::string::npos)
-        {
-            message.replace(pos, 10, city.name);
-        }
-    }
-
-    if (g_AnnounceRadius == 0)
-    {
-        // Announce to the entire world
-        sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, message);
-    }
-    else
-    {
-        // Announce to players in range
-        Map* map = sMapMgr->FindMap(city.mapId, 0);
-        if (map)
-        {
-            Map::PlayerList const& players = map->GetPlayers();
-            for (auto itr = players.begin(); itr != players.end(); ++itr)
-            {
-                if (Player* player = itr->GetSource())
-                {
-                    if (player->GetDistance(city.centerX, city.centerY, city.centerZ) <= g_AnnounceRadius)
-                    {
-                        ChatHandler(player->GetSession()).PSendSysMessage(message.c_str());
-                    }
-                }
-            }
-        }
-    }
+    std::string message = ReplacePlaceholder(isStart ? g_MessageSiegeStart : g_MessageSiegeEnd,
+        "{CITYNAME}", city.name);
+    SendSiegeScopedMessage(city, message);
 
     if (g_DebugMode)
     {
@@ -971,6 +971,63 @@ void SendSiegeDataToPlayer(Player* player, const SiegeEvent& event,
         ss << ":WP:" << city.waypoints.size();
         for (const auto& wp : city.waypoints)
             ss << ":" << std::fixed << std::setprecision(2) << wp.x << ":" << wp.y << ":" << wp.z;
+
+        auto appendCreaturePositions = [&](char const* section, std::vector<ObjectGuid> const& guids)
+        {
+            std::vector<std::array<float, 3>> positions;
+            positions.reserve(guids.size());
+
+            for (ObjectGuid const& guid : guids)
+            {
+                if (Creature* creature = map->GetCreature(guid))
+                {
+                    if (!creature->IsAlive())
+                        continue;
+
+                    positions.push_back({
+                        creature->GetPositionX(),
+                        creature->GetPositionY(),
+                        creature->GetPositionZ()
+                    });
+                }
+            }
+
+            ss << ":" << section << ":" << positions.size();
+            for (std::array<float, 3> const& position : positions)
+                ss << ":" << std::fixed << std::setprecision(2)
+                   << position[0] << ":" << position[1] << ":" << position[2];
+        };
+
+        auto appendBotPositions = [&](char const* section, std::vector<ObjectGuid> const& guids)
+        {
+            std::vector<std::array<float, 3>> positions;
+            positions.reserve(guids.size());
+
+            for (ObjectGuid const& guid : guids)
+            {
+                if (Player* bot = ObjectAccessor::FindPlayer(guid))
+                {
+                    if (!bot->IsInWorld() || !bot->IsAlive())
+                        continue;
+
+                    positions.push_back({
+                        bot->GetPositionX(),
+                        bot->GetPositionY(),
+                        bot->GetPositionZ()
+                    });
+                }
+            }
+
+            ss << ":" << section << ":" << positions.size();
+            for (std::array<float, 3> const& position : positions)
+                ss << ":" << std::fixed << std::setprecision(2)
+                   << position[0] << ":" << position[1] << ":" << position[2];
+        };
+
+        appendCreaturePositions("ATK", event.spawnedCreatures);
+        appendCreaturePositions("DEF", event.spawnedDefenders);
+        appendBotPositions("BATK", event.attackerBots);
+        appendBotPositions("BDEF", event.defenderBots);
     }
     else if (messageType == "END")
     {
@@ -2303,7 +2360,7 @@ void StartSiegeEvent(int targetCityId = -1)
 
     // Announce siege is coming (before RP phase)
     std::string preAnnounce = "|cffff0000[City Siege]|r |cffFFFF00WARNING!|r A siege force is preparing to attack " + city->name + "! The battle will begin in " + std::to_string(g_CinematicDelay) + " seconds. Defenders, prepare yourselves!";
-    sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, preAnnounce);
+    SendSiegeScopedMessage(*city, preAnnounce);
 
     g_ActiveSieges.push_back(newEvent);
 
@@ -2447,30 +2504,7 @@ void EndSiegeEvent(SiegeEvent& event, int winningTeam = -1)
     }
     
     // Send announcement (same logic as AnnounceSiege)
-    if (g_AnnounceRadius == 0)
-    {
-        // Announce to the entire world
-        sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, winnerAnnouncement);
-    }
-    else
-    {
-        // Announce to players in range
-        Map* mapForAnnounce = sMapMgr->FindMap(city.mapId, 0);
-        if (mapForAnnounce)
-        {
-            Map::PlayerList const& players = mapForAnnounce->GetPlayers();
-            for (auto itr = players.begin(); itr != players.end(); ++itr)
-            {
-                if (Player* player = itr->GetSource())
-                {
-                    if (IsPlayerInAnnounceScope(player, city))
-                    {
-                        ChatHandler(player->GetSession()).PSendSysMessage(winnerAnnouncement.c_str());
-                    }
-                }
-            }
-        }
-    }
+    SendSiegeScopedMessage(city, winnerAnnouncement);
     
     if (g_DebugMode)
     {
@@ -2587,71 +2621,35 @@ void DistributeRewards(const SiegeEvent& /*event*/, const CityData& city, int wi
                 }
                 
                 // Send detailed confirmation message with rewards
-                char rewardMsg[512];
                 uint32 goldCoins = goldAwarded / 10000;
                 uint32 silverCoins = (goldAwarded % 10000) / 100;
                 uint32 copperCoins = goldAwarded % 100;
-                
-                if (honorAwarded > 0 && goldAwarded > 0)
+
+                std::ostringstream rewardMessage;
+                rewardMessage << ReplacePlaceholder(
+                    ReplacePlaceholder(g_MessageReward, "{CITYNAME}", city.name),
+                    "{ACTION}", victoryAction);
+
+                if (honorAwarded > 0 || goldAwarded > 0)
+                    rewardMessage << " Received:";
+
+                if (honorAwarded > 0)
+                    rewardMessage << " |cffFFD700" << honorAwarded << " Honor|r";
+
+                if (goldAwarded > 0)
                 {
-                    // Both honor and gold
+                    if (honorAwarded > 0)
+                        rewardMessage << " and";
+
+                    rewardMessage << " |cffFFD700";
                     if (goldCoins > 0)
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%ug %us %uc|r",
-                            victoryAction, city.name.c_str(), honorAwarded, goldCoins, silverCoins, copperCoins);
-                    }
-                    else if (silverCoins > 0)
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%us %uc|r",
-                            victoryAction, city.name.c_str(), honorAwarded, silverCoins, copperCoins);
-                    }
-                    else
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r and |cffFFD700%uc|r",
-                            victoryAction, city.name.c_str(), honorAwarded, copperCoins);
-                    }
+                        rewardMessage << goldCoins << "g ";
+                    if (silverCoins > 0 || goldCoins > 0)
+                        rewardMessage << silverCoins << "s ";
+                    rewardMessage << copperCoins << "c|r";
                 }
-                else if (honorAwarded > 0)
-                {
-                    // Only honor
-                    snprintf(rewardMsg, sizeof(rewardMsg), 
-                        "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%u Honor|r",
-                        victoryAction, city.name.c_str(), honorAwarded);
-                }
-                else if (goldAwarded > 0)
-                {
-                    // Only gold
-                    if (goldCoins > 0)
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%ug %us %uc|r",
-                            victoryAction, city.name.c_str(), goldCoins, silverCoins, copperCoins);
-                    }
-                    else if (silverCoins > 0)
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%us %uc|r",
-                            victoryAction, city.name.c_str(), silverCoins, copperCoins);
-                    }
-                    else
-                    {
-                        snprintf(rewardMsg, sizeof(rewardMsg), 
-                            "|cff00ff00[City Siege]|r You have been rewarded for %s %s! Received: |cffFFD700%uc|r",
-                            victoryAction, city.name.c_str(), copperCoins);
-                    }
-                }
-                else
-                {
-                    // No rewards configured
-                    snprintf(rewardMsg, sizeof(rewardMsg), 
-                        "|cff00ff00[City Siege]|r You have been rewarded for %s %s!",
-                        victoryAction, city.name.c_str());
-                }
-                
-                ChatHandler(player->GetSession()).PSendSysMessage(rewardMsg);
+
+                ChatHandler(player->GetSession()).PSendSysMessage(rewardMessage.str().c_str());
                 
                 rewardedPlayers++;
             }
@@ -3068,19 +3066,19 @@ void UpdateSiegeEvents(uint32 /*diff*/)
             {
                 event.countdown75Announced = true;
                 std::string countdownMsg = "|cffff0000[City Siege]|r |cffFFFF00" + std::to_string(remaining) + " seconds|r until the siege of " + city.name + " begins! Defenders, prepare!";
-                sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, countdownMsg);
+                SendSiegeScopedMessage(city, countdownMsg);
             }
             else if (percentRemaining <= 50.0f && !event.countdown50Announced)
             {
                 event.countdown50Announced = true;
                 std::string countdownMsg = "|cffff0000[City Siege]|r |cffFF8800" + std::to_string(remaining) + " seconds|r until the siege of " + city.name + " begins! Defenders, to your posts!";
-                sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, countdownMsg);
+                SendSiegeScopedMessage(city, countdownMsg);
             }
             else if (percentRemaining <= 25.0f && !event.countdown25Announced)
             {
                 event.countdown25Announced = true;
                 std::string countdownMsg = "|cffff0000[City Siege]|r |cffFF0000" + std::to_string(remaining) + " seconds|r until the siege of " + city.name + " begins! FINAL WARNING!";
-                sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, countdownMsg);
+                SendSiegeScopedMessage(city, countdownMsg);
             }
             
             // RP Script execution during cinematic phase (sequential dialogue from leaders/mini-bosses)
@@ -3144,7 +3142,7 @@ void UpdateSiegeEvents(uint32 /*diff*/)
             
             // Announce battle has begun!
             std::string battleStart = "|cffff0000[City Siege]|r |cffFF0000THE BATTLE HAS BEGUN!|r The siege of " + city.name + " is now underway! Defenders, to arms!";
-            sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, battleStart);
+            SendSiegeScopedMessage(city, battleStart);
             
             // Play combat phase music if enabled
             if (g_MusicEnabled && g_CombatMusicId > 0)
@@ -4182,7 +4180,7 @@ void UpdateSiegeEvents(uint32 /*diff*/)
                 statusMsg += " |cffFFFF00FINAL MINUTES!|r";
             }
             
-            sWorldSessionMgr->SendServerMessage(SERVER_MSG_STRING, statusMsg);
+            SendSiegeScopedMessage(city, statusMsg);
             
             // Broadcast siege update to addons
             BroadcastSiegeDataToAddon(event, "UPDATE");


### PR DESCRIPTION
## Summary
- improve addon sync behavior, siege cleanup, and related addon documentation/config updates
- expose active siege snapshots and add a GetActiveCreatureRole API for siege participant role detection
- protect siege NPCs during cinematics and clean up addon command/stats handling

## Testing
- not run (not requested)